### PR TITLE
Add presence handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ Each command has the following form:
 In the current implementation commands are Request-only, i.e. there is no generic (RPC) mechanism to respond to a command.
 This may change in future versions.
 
+### Known Commands
+
+* `presence popup` Toggles the presence dialog. This command has no arguments.
+
+## MQTT
+
+### Status update
+
+If an MQTT topic is provided in `mqtt.presence-topic` the presence status will be sent as raw status text.
+
 ## Resources
 
 Uses [Free Icons from the Streamline Icons Pack](https://streamlineicons.com/).

--- a/app.py
+++ b/app.py
@@ -17,6 +17,8 @@ from page_gtd import GtdPage
 from page_home import HomePage
 from page_system import SystemPage
 from statusbar import StatusBar, TrayIcon
+from presence_ui import PresenceDlg, Presence, PresencePingTechEmitter
+from presence_conn import PresenceSvcCfg, PingTechPresenceReceiver, PingTechPresenceUpdater, MqttPresenceUpdater
 
 from kivy import Logger
 from kivy.config import Config
@@ -25,7 +27,7 @@ from kivy.core.window import Window
 
 from kivy.clock import Clock
 
-from kivy.properties import ObjectProperty
+from kivy.properties import ObjectProperty, StringProperty, ListProperty
 
 running = True
 
@@ -45,7 +47,18 @@ class TabbedPanelApp(App):
     mqtt_icon = ObjectProperty(None)
     amqp_icon = ObjectProperty(None)
 
+    config = ObjectProperty(None)
     mqttc = ObjectProperty(None)
+    presence_receiver = ObjectProperty(None)
+    presence_emitter = ObjectProperty(None)
+    mqtt_presence_updater = ObjectProperty(None)
+
+    active_presence = StringProperty(None)
+    requested_presence = StringProperty(None)
+
+    handle_self = StringProperty()
+    handle_others = ListProperty()
+    presence_list = ListProperty()
 
     def __init__(self, config, mqttc, **kwargs):
         super().__init__(**kwargs)
@@ -54,6 +67,23 @@ class TabbedPanelApp(App):
         self.mqttc = mqttc
 
         self.ca = None
+        self.pr_sel = None
+
+        self.bind(active_presence=self._on_active_presence)
+        self.property('active_presence').dispatch(self)
+
+        self.bind(presence_list=self._on_presence_list)
+        self.property('presence_list').dispatch(self)
+
+        self.bind(requested_presence=self._on_presence_request)
+
+        self._load_presence_config()
+
+        mqtt_cfg = self._config.get('mqtt', None)
+        if self.mqttc and mqtt_cfg:
+            presence_topic = mqtt_cfg.get('presence-topic', None)
+            if presence_topic:
+                self.mqtt_presence_updater = MqttPresenceUpdater(self.mqttc, presence_topic)
 
     def build(self):
         home_page = HomePage()
@@ -69,7 +99,11 @@ class TabbedPanelApp(App):
         Clock.schedule_once(lambda dt: ca.register_content(system_page))
         Clock.schedule_once(lambda dt: ca.register_content(gtd_page))
 
-        ca.register_status_bar(StatusBar())
+        sb = StatusBar()
+        ca.register_status_bar(sb)
+        self.bind(active_presence=sb.ids.presence.setter('active_presence'))
+        self.property('active_presence').dispatch(self)
+        sb.ids.presence.touch_cb = self.popup_handler
 
         self.mqtt_icon = TrayIcon(label='MQTT', icon="assets/mqtt_icon_64px.png")
         ca.status_bar.tray_bar.register_widget(self.mqtt_icon)
@@ -81,6 +115,112 @@ class TabbedPanelApp(App):
 
         self.ca = ca
         return ca
+
+    def select(self, index):
+        Clock.schedule_once(lambda dt: self.ca.set_page(index))
+
+    def popup_handler(self, _cmd=None, _args=None):
+        Clock.schedule_once(lambda dt: self._presence_load())
+
+        if self.pr_sel is not None and self.pr_sel.is_inactive():
+            self.pr_sel = None
+
+        if self.pr_sel is None:
+            self.pr_sel = PresenceDlg()
+
+            self.pr_sel.handle_self = self.handle_self
+            self.pr_sel.handle_others = self.handle_others
+            self.pr_sel.presence_list = self.presence_list
+
+            # Don't do this bind:
+            #   self.bind(active_presence=self.pr_sel.setter('active_presence'))
+            # This results in dangling property binds and repeated calls of inactive widgets.
+
+            self.pr_sel.active_presence = self.active_presence
+            self.pr_sel.requested_presence = self.requested_presence
+            self.pr_sel.bind(requested_presence=self.setter('requested_presence'))
+
+            self.pr_sel.open()
+        else:
+            self.pr_sel.dismiss()
+            self.pr_sel = None
+
+    def _presence_load(self):
+        self.presence_receiver.receive_status(self._on_presence_loaded,
+                                              self._on_presence_load_failed)
+
+    def _on_presence_loaded(self, remote_presence):
+        for e in self.presence_list:
+            presence = remote_presence.get(e.handle)
+            if presence is not None:
+                e.presence = presence.get('status', "unknown")
+
+            if e.handle == self.handle_self:
+                self.active_presence = e.presence
+
+        self.property('presence_list').dispatch(self)
+
+    def _on_presence_load_failed(self, error):
+        Logger.error("Presence: Error while fetching presence: " + str(error))
+        for e in self.presence_list:
+            e.presence = "unknown"
+
+    def _on_presence_request(self, _instance, value):
+        Clock.schedule_once(lambda dt: self.pr_sel is None or self.pr_sel.dismiss(), timeout=0.25)
+        Clock.schedule_once(lambda dt: setattr(self, 'active_presence', value))
+        Clock.schedule_once(lambda dt: setattr(self.presence_emitter, 'requested_presence', value))
+
+    def _on_active_presence(self, _instance, value):
+        if self.presence_list is not None and len(self.presence_list):
+            p = self.presence_list[0]
+            p.presence = value
+
+        if self.pr_sel is not None:
+            self.pr_sel.active_presence = value
+
+        if self.mqtt_presence_updater is not None and value:
+            self.mqtt_presence_updater.update_status(value)
+
+    def _on_presence_list(self, _instance, _value):
+        if self.pr_sel is not None:
+            self.pr_sel.presence_list = []
+            self.pr_sel.presence_list = self.presence_list
+
+    def _load_presence_config(self):
+        if 'presence' not in self._config:
+            return
+
+        pr = self._config.get('presence', None)
+        if pr is None:
+            return
+
+        self.handle_self = pr.get('self', None)
+        self.handle_others = pr.get('others', [])
+
+        pl = []
+
+        people = pr.get('people', {})
+        if people is not None:
+            for p in [self.handle_self] + self.handle_others:
+                person = people.get(p, None)
+                if person is not None:
+                    presence = Presence(handle=p,
+                                        view_name=person.get('view_name', None),
+                                        avatar=person.get('avatar', None))
+                    pl.append(presence)
+
+        self.presence_list = pl
+
+        presence_svc_cfg = PresenceSvcCfg(
+            svc=pr['svc'],
+            handle=pr['self'],
+            token=pr['token']
+        )
+        self.presence_receiver = PingTechPresenceReceiver(presence_svc_cfg)
+        self.presence_updater = PingTechPresenceUpdater(presence_svc_cfg)
+        self.presence_emitter = PresencePingTechEmitter(presence_updater=self.presence_updater)
+
+        self._presence_load()
 
 
 def command_log(cmd, args):
@@ -122,6 +262,7 @@ async def main():
 
     # TODO bind command handlers
     cmd_dispatch.add_command_handler("test", command_log)
+    cmd_dispatch.add_command_handler("presence popup", app.popup_handler)
 
     await app.async_run()
 

--- a/desktop-panel.cfg.template
+++ b/desktop-panel.cfg.template
@@ -1,6 +1,7 @@
 {
   "mqtt": {
-    "host": "<MQTT Host>"
+    "host": "<MQTT Host>",
+    "presence-topic": "<MQTT presence topic>"
   },
   "amqp": {
     "host": "<AMQP Host>",

--- a/presence_conn.py
+++ b/presence_conn.py
@@ -1,0 +1,129 @@
+""" Module for presence connectivity """
+
+import json
+from functools import partial
+
+from kivy.network.urlrequest import UrlRequest
+
+
+class MqttPresenceUpdater(object):
+    def __init__(self, mqttc, topic):
+        self._mqttc = mqttc
+        self._topic = topic
+
+    def update_status(self, status):
+        self._mqttc.publish(self._topic, status, qos=2)
+
+
+class PresenceSvcCfg(object):
+    def __init__(self, svc, handle, token):
+        if svc is None:
+            raise ValueError("Service URL must be provided")
+
+        if handle is None:
+            raise ValueError("Handle must be provided")
+
+        if token is None:
+            raise ValueError("Token must be provided")
+
+        self._svc = svc
+        self._handle = handle
+        self._token = token
+
+    def auth_headers(self):
+        return {
+            'Authentication': self._token
+        }
+
+    def get_endpoint(self):
+        return self._svc_endpoint("presence")
+
+    def post_endpoint(self):
+        return self._svc_endpoint("presence/" + self._handle)
+
+    def _svc_endpoint(self, endpoint):
+        return self._svc + "/" + endpoint
+
+
+class PingTechPresenceUpdater(object):
+    def __init__(self, svc: PresenceSvcCfg):
+        if svc is None:
+            raise ValueError("Service configuration must be provided!")
+        self._svc = svc
+
+    def update_status(self,
+                      status,
+                      message=None,
+                      update_handler=None,
+                      error_handler=None):
+        presence = {
+            "status": status,
+            "message": message if message else ""
+        }
+
+        body = json.dumps(presence)
+
+        UrlRequest(url=self._svc.post_endpoint(),
+                   method="POST",
+                   req_body=body,
+                   req_headers=self._svc.auth_headers(),
+                   on_success=partial(PingTechPresenceUpdater._on_success, update_handler),
+                   on_failure=partial(PingTechPresenceUpdater._on_failure, error_handler),
+                   on_error=partial(PingTechPresenceUpdater._on_error, error_handler),
+                   timeout=10
+                   )
+
+    @staticmethod
+    def _on_success(update_handler, _request, result):
+        if update_handler:
+            update_handler(result)
+
+    @staticmethod
+    def _on_failure(error_handler, _request, result):
+        if error_handler:
+            error_handler(result)
+
+    @staticmethod
+    def _on_error(error_handler, _request, error):
+        if error_handler:
+            error_handler(str(error))
+
+
+class PingTechPresenceReceiver:
+    def __init__(self, svc: PresenceSvcCfg):
+        if svc is None:
+            raise ValueError("Service configuration must be provided!")
+        self._svc = svc
+
+    def receive_status(self,
+                       list_handler=None,
+                       error_handler=None):
+        UrlRequest(url=self._svc.get_endpoint(),
+                   req_headers=self._svc.auth_headers(),
+                   on_success=partial(PingTechPresenceReceiver._on_presence_json, list_handler),
+                   on_failure=partial(PingTechPresenceReceiver._on_failure, error_handler),
+                   on_error=partial(PingTechPresenceReceiver._on_error, error_handler),
+                   timeout=10
+                   )
+
+    @staticmethod
+    def _on_presence_json(list_handler, _request, result):
+        presence = dict()
+
+        for p in result['entries']:
+            handle = p['handle']
+            del p['handle']
+            presence[handle] = p
+
+        if list_handler:
+            list_handler(presence)
+
+    @staticmethod
+    def _on_failure(error_handler, _request, result):
+        if error_handler:
+            error_handler(result)
+
+    @staticmethod
+    def _on_error(error_handler, _request, error):
+        if error_handler:
+            error_handler(str(error))

--- a/statusbar.py
+++ b/statusbar.py
@@ -114,6 +114,10 @@ Builder.load_string("""
     DateTimeDisplay:
         size_hint_x: None
         
+    PresenceTrayWidget:
+        id: presence
+        size_hint_x: None
+        
     Label:
         # This is a placeholder to stretch out the status bar
         


### PR DESCRIPTION
Adds handling for the PingTech presence:
* Integrate presence dialog into main window
* Send current  presence to an MQTT topic
* Popup dialog on AMQP command `presence popup`
* Interact with the PingTech presence service

More work needs to be done on the main window and on moving the presence handling methods deeper into the presence UI.

This PR is part of a project to use the [PingBoardDaemon](https://github.com/penguineer/PingBoardDaemon) for PingBoard integration into the Desktop panel. This PR (together with local NodeRed configuration) restores the original behavior, but makes the other buttons available to applications outside the DesktopPanel.

The PingBoard handler is not used anymore, but will be left here for future reference.