### PR TITLE
:sparkles: Reload configuration without application restart

### DIFF
--- a/globalcontent.py
+++ b/globalcontent.py
@@ -254,7 +254,7 @@ class GlobalContentArea(AnchorLayout):
         super(GlobalContentArea, self).__init__(**kwargs)
 
         self.bind(conf=self._on_conf)
-        self.bind(conf=self._on_mqttc)
+        self.bind(mqttc=self._on_mqttc)
 
     def _on_conf(self, _instance, _conf: dict) -> None:
         for page in self._pages:

--- a/issues.py
+++ b/issues.py
@@ -116,6 +116,7 @@ class IssueList(BoxLayout):
     def _on_conf(self, _instance, conf: dict) -> None:
         if self._observer:
             self._observer.teardown()
+            self._observer = None
 
         path = conf.get("path", None) if conf else None
 

--- a/reloadable_json.py
+++ b/reloadable_json.py
@@ -1,0 +1,56 @@
+""" Module for reloadable JSON files """
+
+import json
+from typing import Callable, Optional
+
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
+from kivy import Logger
+
+
+class JsonObserver(FileSystemEventHandler):
+    def __init__(self,
+                 json_path: str,
+                 update_callback: Callable[[json], None],
+                 failed_callback: Optional[Callable[[bool], None]] = None):
+        if not json_path:
+            raise ValueError("JSON file path must be provided!")
+
+        self._json_path = json_path
+
+        if not update_callback:
+            raise ValueError("Update callback must be provided!")
+        self._update_callback = update_callback
+
+        self._failed_callback = failed_callback
+
+        self._observer = None
+
+    def setup(self):
+        self._observer = Observer()
+        self._observer.schedule(self,
+                                self._json_path,
+                                recursive=False)
+        try:
+            self._observer.start()
+        except FileNotFoundError as e:
+            self._observer = None
+            raise e
+
+    def teardown(self):
+        if self._observer is not None and self._observer.is_alive():
+            self._observer.join()
+
+    def on_modified(self, _event):
+        try:
+            with open(self._json_path, "r") as f:
+                self._update_callback(json.load(f))
+                if self._failed_callback is not None:
+                    self._failed_callback(False)
+        except FileNotFoundError as e:
+            Logger.warning("Issues: %s", e)
+        except json.decoder.JSONDecodeError as e:
+            if self._failed_callback is not None:
+                self._failed_callback(True)
+            Logger.warning("Issues: %s", e)

--- a/reloadable_json.py
+++ b/reloadable_json.py
@@ -40,6 +40,7 @@ class JsonObserver(FileSystemEventHandler):
 
     def teardown(self):
         if self._observer is not None and self._observer.is_alive():
+            self._observer.stop()
             self._observer.join()
 
     def on_modified(self, _event):


### PR DESCRIPTION
With the changes to the configuration structure in #34 #36 and #37 we can now make the configuration reloadable, i.e. if the configuration file is changed the application does not need to be restarted to apply the changes.

There are still some minor issues with this function:
* An active presence selector dialog is not updated (needs rework in #35)
* MQTT connections are not renewed (#38)
* AMQP connections are not renewed (#39)

As these parts need an extensive rework anyways, this feature is merged as is, with issues for the open tasks.
