### PR TITLE
:bug: Fix screensaver influence

### DIFF
--- a/backlight.py
+++ b/backlight.py
@@ -41,8 +41,9 @@ class BacklightControl(Widget):
     def _on_conf(self, _instance, _value):
         # cache maximal brightness setting
         self._max_br = min(100, self.conf.get("brightness", 100) if self.conf else 100)
-        # update
-        self._on_brightness(_instance, _value)
+        # update, if switched on
+        if self.power:
+            self._on_brightness(_instance, _value)
 
     def _on_brightness(self, _instance, _value):
         if self._backlight:

--- a/globalcontent.py
+++ b/globalcontent.py
@@ -1,3 +1,4 @@
+from kivy.core.window import Window
 from kivy.lang import Builder
 
 from kivy.uix.anchorlayout import AnchorLayout
@@ -272,7 +273,7 @@ class GlobalContentArea(AnchorLayout):
 
         # Wake up the screensaver on every touch event
         # Blocks the event if the screen saver is active, so that the user is not poking in the dark (literally)
-        self.bind(on_touch_down=lambda i, e: self.ids.screensaver.wake_up())
+        Window.bind(on_touch_down=lambda i, e: self.ids.screensaver.wake_up())
 
     def _on_conf(self, _instance, _conf: dict) -> None:
         for page in self._pages:


### PR DESCRIPTION
Fix that the screen saver would not hide input from modal views and changes in brightness settings would activate the backlight even  if the screensaver is active.

There is still the problem that a modal view hides the screensaver, i.e. is always visible (see #47 )