### PR TITLE
:sparkles: Disable screensaver when a modal dialog is open

### DIFF
--- a/dlg.py
+++ b/dlg.py
@@ -1,5 +1,5 @@
 from kivy.lang import Builder
-from kivy.properties import ColorProperty, StringProperty
+from kivy.properties import ColorProperty, StringProperty, ObjectProperty
 from kivy.uix.modalview import ModalView
 
 Builder.load_string("""
@@ -110,13 +110,32 @@ class FullscreenTimedModal(ModalView):
 
     title = StringProperty("")
 
+    screensaver = ObjectProperty(None, allownone=True)
+    """ Expects a screensaver instance. If set, the dialog will disable the screensaver
+        while it is open.
+    """
+
     def __init__(self, title=None, **kwargs):
         super(FullscreenTimedModal, self).__init__(**kwargs)
 
         self.ids.CloseBtn.bind(on_press=self.dismiss)
+
+        self.bind(on_open=self._on_open)
+        self.bind(on_dismiss=self._on_dismiss)
 
         if title is not None:
             self.title = title
 
     def is_inactive(self):
         return self._window is None
+
+    def _on_open(self, _e):
+        if self.screensaver:
+            self.screensaver.disabled = True
+
+    def _on_dismiss(self, _e):
+        if self.screensaver:
+            self.screensaver.disabled = False
+
+        # return False to actually dismiss the window
+        return False

--- a/globalcontent.py
+++ b/globalcontent.py
@@ -143,6 +143,8 @@ Builder.load_string("""
     anchor_y: 'top'
     anchor_x: 'left'
     
+    screensaver: screensaver
+    
     canvas:
         #:set border_spacing 10
         Color:
@@ -185,6 +187,7 @@ Builder.load_string("""
                 id: StatusBar
                 conf: root.conf
                 mqttc: root.mqttc
+                screensaver: root.screensaver
     
             AnchorLayout:          
                 size: [root.width - root.tab_width-4, root.height - root.status_height - 4]
@@ -216,6 +219,8 @@ class GlobalContentArea(AnchorLayout):
 
     mqttc = ObjectProperty(None)
     """MQTT client for the application"""
+
+    screensaver = ObjectProperty(None, allownone=True)
 
     background_color = ColorProperty([0, 0, 0, 1])
     """Background color, in the format (r, g, b, a).

--- a/presence_ui.py
+++ b/presence_ui.py
@@ -585,6 +585,7 @@ Builder.load_string("""
 class PresenceTrayWidget(RelativeLayout):
     conf = DictProperty(None, allownone=True)
     mqttc = ObjectProperty(None, allownone=True)
+    screensaver = ObjectProperty(None, allownone=True)
 
     active_presence = ObjectProperty(None, allownone=True)
 
@@ -626,6 +627,9 @@ class PresenceTrayWidget(RelativeLayout):
 
             self.pr_sel.request_callback = self.ids.change_handler.post_status
             # This cannot change
+
+            self.pr_sel.screensaver = self.screensaver
+            self.bind(screensaver=self.pr_sel.setter('screensaver'))
 
             self.pr_sel.handle_self = self.handle_self
             self.bind(handle_self=self.pr_sel.setter('handle_self'))

--- a/statusbar.py
+++ b/statusbar.py
@@ -153,6 +153,7 @@ Builder.load_string("""
         PresenceTrayWidget:
             id: presence
             mqttc: root.mqttc
+            screensaver: root.screensaver
             size_hint_x: None
             
         SpaceStatusWidget:
@@ -172,6 +173,7 @@ Builder.load_string("""
 class StatusBar(RelativeLayout):
     conf = DictProperty(None)
     mqttc = ObjectProperty(None)
+    screensaver = ObjectProperty(None, allownone=True)
 
     def __init__(self, **kwargs):
         super(RelativeLayout, self).__init__(**kwargs)


### PR DESCRIPTION
This makes #47 rather a technical debt than a bug, because the issue cannot occur (as long as all modal dialogs are derived from `FullscreenTimedModal`.