### PR TITLE
:lipstick: Increase padding for system panel

### DIFF
--- a/page_system.py
+++ b/page_system.py
@@ -18,7 +18,7 @@ Builder.load_string("""
     AnchorLayout:
         anchor_x: 'right'
         anchor_y: 'bottom'
-        padding: 10
+        padding: [0, 0, 20, 10]
     
         BoxLayout:
             size: 95, 160


### PR DESCRIPTION
Add 10px to the right padding so that the widget is not clipped on the Raspberry Pi screen.