### PR TITLE
Adjust System page layout for variable temperature gauges

### DIFF
--- a/page_system.py
+++ b/page_system.py
@@ -21,12 +21,14 @@ Builder.load_string("""
         padding: [0, 0, 20, 10]
     
         BoxLayout:
-            size: 95, 160
             orientation: 'vertical'
             spacing: 10
             size_hint: None, None
+            width: temperatures.width
+            height: temperatures.height + power.height + 10
     
             PowerWidget:
+                id: power
                 conf: root.conf.get("power", {}) if root.conf else {}
                 mqttc: root.mqttc
     


### PR DESCRIPTION
This pull request includes a change to the `page_system.py` file to dynamically adjust the size of a `BoxLayout` based on the dimensions, and therefore amount, of sensor gauges. The most important change is the modification of the `BoxLayout` size properties.

Changes to layout size:

* [`page_system.py`](diffhunk://#diff-813c08a8b9fcd2de74f83f2e84b8d20fc4ffb8b248d2bb2589c5d09c933c3c90L24-R31): Adjusted the `BoxLayout` width and height to match the dimensions of the `temperatures` and `power` widgets, respectively. This ensures that the layout dynamically resizes based on the content it holds.