### PR TITLE
Update the GitHub workflows

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install python
       uses: actions/setup-python@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,17 +3,21 @@ name: Create Release
 on:
   push:
     tags:
-      - "v*"
+      - 'v*.*.*'
 
 jobs:
-  build:
-    name: "Release"
+  release:
+
     runs-on: ubuntu-latest
+
     steps:
-      - name: "Check-out"
-        uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
+          ref: ${{ github.ref }}
+          # Needed for correct Maven version detection
           fetch-depth: 0
+
       - name: "Generate release changelog"
         id: generate-release-changelog
         uses: heinrichreimer/github-changelog-generator-action@v2.3
@@ -22,15 +26,17 @@ jobs:
           onlyLastTag: "true" # set to false if no tags exist (buggy with only one tag)
           stripHeaders: "true"
           stripGeneratorNotice: "true"
+
       - name: Extract the VERSION name
         id: get-version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
       - name: "Create GitHub release"
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.ref }}
           name: "${{ steps.get-version.outputs.VERSION }}"
           body: "${{ steps.generate-release-changelog.outputs.changelog }}"
-          prerelease: ${{ startsWith(steps.get-version.outputs.VERSION, 'v0.') }}
+          prerelease: false
           token: ${{ secrets.GITHUB_TOKEN }}
-          draft: True
+          draft: true


### PR DESCRIPTION
This pull request updates the GitHub workflows to use more recent Actions and incorporate improvements made in more recent projects.

Updates to GitHub Actions workflows:

* [`.github/workflows/docker-image.yml`](diffhunk://#diff-dbade1e5797a7633e024a7685a43a7cbd96ae6fefc6314294807ae34cd83712cL18-R18): Updated `actions/checkout` from version 3 to version 4.
* [`.github/workflows/pytest.yml`](diffhunk://#diff-2500680f4bc6c1b75c3d4b36372bf4d64c5f603b90bfd7a5186f66a20329d16aL14-R14): Updated `actions/checkout` from version 3 to version 4.

Improvements to release workflow:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L6-R20): Updated `actions/checkout` from version 3 to version 4, changed tag pattern to `v*.*.*`, renamed job from `build` to `release`, and added `ref` parameter to checkout step.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R29-R42): Modified the step to extract the version name to use `$GITHUB_OUTPUT` instead of `set-output`, and changed `prerelease` to `false` and `draft` to `true` in the GitHub release step.