### PR TITLE
Reset screensaver also when switching to the same page

### DIFF
--- a/app.py
+++ b/app.py
@@ -156,7 +156,7 @@ class TabbedPanelApp(App):
     def _schedule_show_page(self, _cmd, args):
         handle = args.get("page", None)
         if handle:
-            Clock.schedule_once(lambda dt: self.ca.router.switch_to(handle))
+            Clock.schedule_once(lambda dt: self.ca.router.switch_to_label(handle))
 
     def schedule_update_configuration(self, conf):
         Clock.schedule_once(lambda dt: self.setter('conf')(self, conf))

--- a/globalcontent.py
+++ b/globalcontent.py
@@ -75,6 +75,9 @@ class PageRouter(object):
         if page is None:
             return False
 
+        if trip_screensaver and self._on_wake_screensaver:
+            self._on_wake_screensaver()
+
         if self._current_page is page:
             return True
 

--- a/globalcontent.py
+++ b/globalcontent.py
@@ -46,23 +46,23 @@ class PageRouter(object):
         self._pages_by_handle[handle] = page
 
         cbtn = page.create_context_button(length=self._tab_height)
-        cbtn.page_callback = lambda h=handle: self.switch_to(h)
+        cbtn.page_callback = lambda h=handle: self.switch_to_label(h)
         self._context_buttons_panel.add_widget(cbtn)
 
         if self._current_page is None:
-            self.switch_to(handle)
+            self.switch_to_label(handle)
 
     def register_border_button(self, widget, page=None):
         """Register a border (tray) widget, optionally wiring it to a page."""
         if page is not None:
             handle = page.label
             self._pages_by_handle[handle] = page
-            widget.page_callback = lambda h=handle: self.switch_to(h)
+            widget.page_callback = lambda h=handle: self.switch_to_label(h)
 
             if self._current_page is None:
-                self.switch_to(handle)
+                self.switch_to_label(handle)
 
-    def switch_to(self, handle: str, trip_screensaver: bool = True) -> bool:
+    def switch_to_label(self, handle: str, trip_screensaver: bool = True) -> bool:
         """Switch to the page identified by *handle*.
 
         :param handle: The page label to switch to.
@@ -97,7 +97,7 @@ class PageRouter(object):
 
     def switch_to_page(self, page, trip_screensaver: bool = True):
         """Convenience: switch by page object rather than handle string."""
-        return self.switch_to(page.label, trip_screensaver=trip_screensaver)
+        return self.switch_to_label(page.label, trip_screensaver=trip_screensaver)
 
 
 class ContentPage(RelativeLayout):
@@ -436,7 +436,7 @@ class GlobalContentArea(AnchorLayout):
 
     def set_page(self, page):
         if 0 <= page < len(self._pages):
-            self._router.switch_to(self._pages[page].label)
+            self._router.switch_to_label(self._pages[page].label)
 
     def register_content(self, page):
         self._pages.append(page)

--- a/globalcontent.py
+++ b/globalcontent.py
@@ -72,9 +72,6 @@ class PageRouter(object):
         :returns: ``True`` if the page was found and switched to.
         """
         page = self._pages_by_handle.get(handle)
-        if page is None:
-            return False
-
         return self.switch_to_page(page, trip_screensaver=trip_screensaver)
 
     def switch_to_page(self, page, trip_screensaver: bool = True):
@@ -86,6 +83,9 @@ class PageRouter(object):
             silently without affecting the screensaver.
         :returns: ``True`` if the page was found and switched to.
         """
+
+        if page is None:
+            return False
 
         if trip_screensaver and self._on_wake_screensaver:
             self._on_wake_screensaver()

--- a/globalcontent.py
+++ b/globalcontent.py
@@ -75,6 +75,18 @@ class PageRouter(object):
         if page is None:
             return False
 
+        return self.switch_to_page(page, trip_screensaver=trip_screensaver)
+
+    def switch_to_page(self, page, trip_screensaver: bool = True):
+        """Switch to the page.
+
+        :param page: The page to switch to.
+        :param trip_screensaver: When ``True`` (default), wake the screensaver
+            so the screen becomes visible.  Pass ``False`` to change the page
+            silently without affecting the screensaver.
+        :returns: ``True`` if the page was found and switched to.
+        """
+
         if trip_screensaver and self._on_wake_screensaver:
             self._on_wake_screensaver()
 
@@ -93,14 +105,7 @@ class PageRouter(object):
         if self._on_page_changed:
             self._on_page_changed(page)
 
-        if trip_screensaver and self._on_wake_screensaver:
-            self._on_wake_screensaver()
-
         return True
-
-    def switch_to_page(self, page, trip_screensaver: bool = True):
-        """Convenience: switch by page object rather than handle string."""
-        return self.switch_to_label(page.label, trip_screensaver=trip_screensaver)
 
 
 class ContentPage(RelativeLayout):


### PR DESCRIPTION
This PR fixes that switching to an already active page did not reset the screensaver, meaning that the user would not see the switch.

Alsp  refactors the `switch_to` → `switch_to_page`  and `switch_to_label` for more consistent naming and better structrure.