### PR TITLE
Set up Dependabot for GH action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    groups:
+      gitub-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This pull request adds a Dependabot configuration file to automate dependency updates for GitHub Actions workflows. This ensures that GitHub Actions dependencies are checked and updated on a weekly basis.

Dependency management automation:

* Added a `.github/dependabot.yml` file to enable weekly automated updates for GitHub Actions dependencies, grouping all updates under the "dependencies" label.