### PR TITLE
Add block_input parameter to show page AMQP call

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This may change in future versions.
 ### Known Commands
 
 * `screenshot` Takes a screenshot and stores in the working directory. This command has no arguments.
-* `show page` Toggles to the page given in the `page` argument. In addition, specify `go_back_if_current` to pop the navigation stack if the page is already active.
+* `show page` Toggles to the page given in the `page` argument. In addition, specify `go_back_if_current: True` to pop the navigation stack if the page is already active and `block_input: True` to block user input to avoid clickjacking.
 
 ### Syslog Channel
 

--- a/app.py
+++ b/app.py
@@ -157,11 +157,12 @@ class TabbedPanelApp(App):
     def _schedule_show_page(self, _cmd, args):
         handle = args.get("page", None)
         go_back_if_current = args.get("go_back_if_current", False)
+        block_input = args.get("block_input", False)
         if handle:
             Clock.schedule_once(
                 lambda dt: self.ca.router.switch_to_label(handle,
                                                           go_back_if_current=go_back_if_current,
-                                                          block_input=True))
+                                                          block_input=block_input))
 
     def schedule_update_configuration(self, conf):
         Clock.schedule_once(lambda dt: self.setter('conf')(self, conf))


### PR DESCRIPTION
This pull request updates the handling of the `show page` command to provide more flexibility and improve documentation. The most important changes are:

**Feature enhancements:**

* Added support for a `block_input` argument to the `show page` command, allowing the caller to specify whether user input should be blocked to prevent clickjacking. The value for `block_input` is now configurable instead of always being set to `True`.

**Documentation updates:**

* Updated the `README.md` to document the new `block_input` argument for the `show page` command, clarifying its usage and purpose.